### PR TITLE
Add: load param encoding='latin1'

### DIFF
--- a/load_cifar.py
+++ b/load_cifar.py
@@ -1,4 +1,4 @@
-import cPickle
+import pickle as cPickle
 import numpy as np
 import random
 random.seed(1) # set a seed so that the results are consistent
@@ -8,7 +8,7 @@ def load_batch():
     file = 'data_batch_1'
 
     f = open(path+file, 'rb')
-    dict = cPickle.load(f)
+    dict = cPickle.load(f, encoding='latin1')
     images = dict['data']
     #images = np.reshape(images, (10000, 3, 32, 32))
     labels = dict['labels']


### PR DESCRIPTION
When I run this code on GoogleColab (python v3.6)

I got this error.
[UnicodeDecodeError: 'ascii' codec can't decode byte 0x8b in position 6: ordinal not in range(128) site:stackoverflow.com]
https://stackoverflow.com/questions/42940851/unicodedecodeerror-ascii-codec-cant-decode-byte-0x8b

And python3 doesn't have  cPickle, so I replace it by pickle.